### PR TITLE
Include <functional> when needed

### DIFF
--- a/external/rocksdb/utilities/persistent_cache/block_cache_tier_file.h
+++ b/external/rocksdb/utilities/persistent_cache/block_cache_tier_file.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <functional>
 
 #include "rocksdb/comparator.h"
 #include "rocksdb/env.h"

--- a/external/rocksdb/utilities/persistent_cache/hash_table.h
+++ b/external/rocksdb/utilities/persistent_cache/hash_table.h
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <list>
 #include <vector>
+#include <functional>
 
 #ifdef OS_LINUX
 #include <sys/mman.h>


### PR DESCRIPTION
`std::function` is in `<functional>`. Include `<functional>` to prevent possible compiler errors.